### PR TITLE
Edm calibration forms flows

### DIFF
--- a/baseline_calibration/templates/baseline_calibration/baseline_calibration_home.html
+++ b/baseline_calibration/templates/baseline_calibration/baseline_calibration_home.html
@@ -53,7 +53,7 @@
                   <td>{{ pillar_survey.survey_date }} </td>
                   <td>{{ pillar_survey.accreditation.accredited_company }}</td>
                   <td>{{ pillar_survey.observer }} </td>
-                  {% if not pillar_survey.modified_on is null %}
+                  {% if pillar_survey.variance is not null %}
                       <td>{{ pillar_survey.modified_on }}</td>
                   {% else %}  
                       <td>In progress ..</td>

--- a/baseline_calibration/templates/baseline_calibration/calibrate_report.html
+++ b/baseline_calibration/templates/baseline_calibration/calibrate_report.html
@@ -72,7 +72,9 @@
                     <br><B>Manufacturers Uncertainty: </B>{{ pillar_survey.edm.edm_specs.manu_unc_const }}mm &plusmn {{ pillar_survey.edm.edm_specs.manu_unc_ppm }}ppm, k={{ pillar_survey.edm.edm_specs.manu_unc_k }}
                     <br><B>Carrier Wavelength: </B>{{ pillar_survey.edm.edm_specs.carrier_wavelength }}nm
                     <br><B>Calibration Date : </B>{{ calib.edmi.0.calibration_date }}
-                    <br><a href="{{ calib.edmi.0.calibration_date.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>
+                    {% if calib.edmi.0.certificate_upload %}
+                        <br><a href="{{ calib.edmi.0.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>
+                    {% endif %}
                 </div>
             </div>
             <div class="flexbox-container_IB">
@@ -97,7 +99,9 @@
                 <div class="flexbox-item_400_IB  flexbox-item-right_IB">
                     <br><br><B>Staff Length: </B>{{ pillar_survey.staff.staff_length }} m
                     <br><B>Calibration Date: </B>{{ calib.staff.calibration_date }}
-                    <br><a href="{{ calib.staff.calibration_date.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>
+                    {% if calib.staff.calibration_date.certificate_upload %}
+                        <br><a href="{{ calib.staff.calibration_date.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>
+                    {% endif %}
                 </div>
             </div>
             <div class="flexbox-container_IB">
@@ -110,7 +114,9 @@
                 <div class="flexbox-item_400_IB  flexbox-item-right_IB">
                     <br><br><B>Manufacturers Uncertainty: </B>{{ pillar_survey.thermometer.mets_specs.manu_unc_const }} &#186C, k={{ pillar_survey.thermometer.mets_specs.manu_unc_k }}
                     <br><B>Calibration Date: </B>{{ calib.them.calibration_date }}
-                    <br><a href="{{ calib.them.calibration_date.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>
+                    {% if calib.them.calibration_date.certificate_upload %}
+                        <br><a href="{{ calib.them.calibration_date.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>
+                    {% endif %}
                 </div>
             </div>
             <div class="flexbox-container_IB">
@@ -123,7 +129,9 @@
                 <div class="flexbox-item_400_IB  flexbox-item-right_IB">
                     <br><br><B>Manufacturers Uncertainty: </B>{{ pillar_survey.barometer.mets_specs.manu_unc_const }} hPa, k={{ pillar_survey.barometer.mets_specs.manu_unc_k }}
                     <br><B>Calibration Date: </B>{{ calib.baro.calibration_date }}
-                    <br><a href="{{ calib.baro.calibration_date.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>
+                    {% if calib.baro.calibration_date.certificate_upload %}
+                        <br><a href="{{ calib.baro.calibration_date.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>
+                    {% endif %}
                 </div>
             </div>
             <div class="flexbox-container_IB">
@@ -136,7 +144,9 @@
                 <div class="flexbox-item_400_IB  flexbox-item-right_IB">
                     <br><br><B>Manufacturers Uncertainty: </B>{{ pillar_survey.hygrometer.mets_specs.manu_unc_const }} &#37, k={{ pillar_survey.hygrometer.mets_specs.manu_unc_k }}
                     <br><B>Calibration Date: </B>{{ calib.hygro.calibration_date }}
-                    <br><a href="{{ calib.hygro.calibration_date.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>
+                    {% if calib.hygro.calibration_date.certificate_upload %}
+                        <br><a href="{{ calib.hygro.calibration_date.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>
+                    {% endif %}
                 </div>
             </div>
             <div class="flexbox-container_IB">
@@ -567,7 +577,11 @@
             <div class="flexbox-container_IB">
                 <div class="flexbox-item_800_IB flexbox-item-button_IB">
                     <a href= "{% url 'baseline_calibration:calibrate2' id=pillar_survey.pk %}" class="submit-button bg-green-500 hover:bg-green-400" style="text-align: center">Back</a>
-                    <a href= "{% url 'baseline_calibration:pillar_survey_del' id=pillar_survey.pk %}" class="submit-button bg-red-500 hover:bg-green-400" style="text-align: center"> Cancel</a>
+                    {% if pillar_survey.variance is not null %}
+                        <a href= "{% url 'baseline_calibration:calibration_home' %}" class="submit-button bg-red-500 hover:bg-green-400" style="text-align: center"> Cancel</a>
+                    {% else %}
+                        <a href= "{% url 'baseline_calibration:pillar_survey_del' id=pillar_survey.pk %}" class="submit-button bg-red-500 hover:bg-green-400" style="text-align: center"> Cancel</a>
+                    {% endif %}
                     <button type="submit" class="submit-button bg-green-500 hover:bg-green-400" >Save</button>
                 </div>
             </div>

--- a/baseline_calibration/templates/baseline_calibration/calibrate_report.html
+++ b/baseline_calibration/templates/baseline_calibration/calibrate_report.html
@@ -99,8 +99,8 @@
                 <div class="flexbox-item_400_IB  flexbox-item-right_IB">
                     <br><br><B>Staff Length: </B>{{ pillar_survey.staff.staff_length }} m
                     <br><B>Calibration Date: </B>{{ calib.staff.calibration_date }}
-                    {% if calib.staff.calibration_date.certificate_upload %}
-                        <br><a href="{{ calib.staff.calibration_date.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>
+                    {% if calib.staff.certificate_upload %}
+                        <br><a href="{{ calib.staff.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>
                     {% endif %}
                 </div>
             </div>
@@ -114,8 +114,8 @@
                 <div class="flexbox-item_400_IB  flexbox-item-right_IB">
                     <br><br><B>Manufacturers Uncertainty: </B>{{ pillar_survey.thermometer.mets_specs.manu_unc_const }} &#186C, k={{ pillar_survey.thermometer.mets_specs.manu_unc_k }}
                     <br><B>Calibration Date: </B>{{ calib.them.calibration_date }}
-                    {% if calib.them.calibration_date.certificate_upload %}
-                        <br><a href="{{ calib.them.calibration_date.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>
+                    {% if calib.them.certificate_upload %}
+                        <br><a href="{{ calib.them.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>
                     {% endif %}
                 </div>
             </div>
@@ -129,8 +129,8 @@
                 <div class="flexbox-item_400_IB  flexbox-item-right_IB">
                     <br><br><B>Manufacturers Uncertainty: </B>{{ pillar_survey.barometer.mets_specs.manu_unc_const }} hPa, k={{ pillar_survey.barometer.mets_specs.manu_unc_k }}
                     <br><B>Calibration Date: </B>{{ calib.baro.calibration_date }}
-                    {% if calib.baro.calibration_date.certificate_upload %}
-                        <br><a href="{{ calib.baro.calibration_date.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>
+                    {% if calib.baro.certificate_upload %}
+                        <br><a href="{{ calib.baro.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>
                     {% endif %}
                 </div>
             </div>
@@ -144,8 +144,8 @@
                 <div class="flexbox-item_400_IB  flexbox-item-right_IB">
                     <br><br><B>Manufacturers Uncertainty: </B>{{ pillar_survey.hygrometer.mets_specs.manu_unc_const }} &#37, k={{ pillar_survey.hygrometer.mets_specs.manu_unc_k }}
                     <br><B>Calibration Date: </B>{{ calib.hygro.calibration_date }}
-                    {% if calib.hygro.calibration_date.certificate_upload %}
-                        <br><a href="{{ calib.hygro.calibration_date.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>
+                    {% if calib.hygro.certificate_upload %}
+                        <br><a href="{{ calib.hygro.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>
                     {% endif %}
                 </div>
             </div>

--- a/baseline_calibration/templates/baseline_calibration/edm_rawdata.html
+++ b/baseline_calibration/templates/baseline_calibration/edm_rawdata.html
@@ -5,70 +5,74 @@
 {% block content %} 
 
 <article class="post">
-	<div class="page-content">
+    <div class="page-content">
         <div class="text-center">
             <h1>Imported EDM Observations</h1>
         </div>
     <form action="" style="font-size:10.0pt;width:4500px;" class="site-form" method="post" enctype="multipart/form-data">               
         <div class="flexbox-container_IB flexbox-item-left_IB">
-        		<p>The pillar survey observations are used to calculate the baseline's 'certified distances'<a href= "#"> &#x1F6C8</a>
+                <p>The pillar survey observations are used to calculate the baseline's 'certified distances'<a href= "#"> &#x1F6C8</a>
                and the pillar offsets from the first pillar to last pillar alignment.<a href= "#"> &#x1F6C8</a>
                <br>Please select/deselect the observations in the following table to use for the alignment and/or distance calculations.</p>                 
         </div>  
         <div class="flexbox-container_IB" style="width: 100%;">
-        		<div class="flexbox-item_400_IB"><i>* Click the table headers to sort table</i></div>
-	        	<div class="flexbox-item_IB" style="width: 100%;text-align:right"><a href="#bottom">Scroll to bottom &#128317</a></div>
+                <div class="flexbox-item_400_IB"><i>* Click the table headers to sort table</i></div>
+                <div class="flexbox-item_IB" style="width: 100%;text-align:right"><a href="#bottom">Scroll to bottom &#128317</a></div>
         </div>
         <div class="flexbox-container_IB flexbox-item_IB" style="min-width: 600px;">
-		        {% csrf_token %}
-						<table id="obsTable">
-		                {{ edm_obs_formset.management_form }}
-		                {% for form, raw in formset %}
-		                    {% if forloop.first %}
-		                    <tr>
-			                      <th onclick="sortTable(0)"> Obs # </th>
-			                      <th onclick="sortTable(1)"> From Pillar </th>
-			                      <th onclick="sortTable(2)"> To Pillar </th>
-			                      <th onclick="sortTable(3)"> Instrument Height (m)</th>
-			                      <th onclick="sortTable(4)"> Target Height (m)</th>
-			                      <th onclick="sortTable(5)"> Slope Distance (m)</th>
-			                      <th onclick="sortTable(6)"> Offset (m)</th>
-			                      <th onclick="sortTable(7)"> Raw Temperature (°C) </th>
-			                      <th onclick="sortTable(8)"> Raw Pressure (mBar) </th>
-			                      <th onclick="sortTable(9)"> Raw Humidity (%) </th>
-			                      <th onclick="sortTable(10)"> Select for Alignment Survey </th>
-			                      <th onclick="sortTable(11)"> Select for Certified Distances </th>
-		                        <td style="display: none;"></td>
-		                    </tr>
-		                    {% endif %}
-		                    <tr>
-		                        <td>{{ forloop.counter|stringformat:"03d" }}</td>
-		                        <td>{{ raw.from_pillar }}</td>
-		                        <td>{{ raw.to_pillar }}</td>
-		                        <td>{{ raw.inst_ht|floatformat:3 }}</td>
-		                        <td>{{ raw.tgt_ht|floatformat:3 }}</td>
-		                        <td>{{ raw.raw_slope_dist|floatformat:4 }}</td>
-		                        <td>{{ raw.observed_offset|floatformat:3 }}</td>
-		                        <td>{{ raw.raw_temperature|floatformat:1 }}</td>
-		                        <td>{{ raw.raw_pressure|floatformat:1 }}</td>
-		                        <td>{{ raw.raw_humidity|floatformat:1 }}</td>
-		                        <td style="text-align:center">{{ form.use_for_alignment }}</td>
-		                        <td style="text-align:center">{{ form.use_for_distance }}</td>
-		                        <td style="display: none;">{{ form.id }}</td>
-		                    </tr>
-		                    {% endfor %}
-		      	</table>
-      	</div>
+            {% csrf_token %}
+            <table id="obsTable">
+                {{ edm_obs_formset.management_form }}
+                {% for form, raw in formset %}
+                    {% if forloop.first %}
+                        <tr>
+                            <th onclick="sortTable(0)"> Obs # </th>
+                            <th onclick="sortTable(1)"> From Pillar </th>
+                            <th onclick="sortTable(2)"> To Pillar </th>
+                            <th onclick="sortTable(3)"> Instrument Height (m)</th>
+                            <th onclick="sortTable(4)"> Target Height (m)</th>
+                            <th onclick="sortTable(5)"> Slope Distance (m)</th>
+                            <th onclick="sortTable(6)"> Offset (m)</th>
+                            <th onclick="sortTable(7)"> Raw Temperature (°C) </th>
+                            <th onclick="sortTable(8)"> Raw Pressure (mBar) </th>
+                            <th onclick="sortTable(9)"> Raw Humidity (%) </th>
+                            <th onclick="sortTable(10)"> Select for Alignment Survey </th>
+                            <th onclick="sortTable(11)"> Select for Certified Distances </th>
+                            <td style="display: none;"></td>
+                        </tr>
+                    {% endif %}
+                    <tr>
+                        <td>{{ forloop.counter|stringformat:"03d" }}</td>
+                        <td>{{ raw.from_pillar }}</td>
+                        <td>{{ raw.to_pillar }}</td>
+                        <td>{{ raw.inst_ht|floatformat:3 }}</td>
+                        <td>{{ raw.tgt_ht|floatformat:3 }}</td>
+                        <td>{{ raw.raw_slope_dist|floatformat:4 }}</td>
+                        <td>{{ raw.observed_offset|floatformat:3 }}</td>
+                        <td>{{ raw.raw_temperature|floatformat:1 }}</td>
+                        <td>{{ raw.raw_pressure|floatformat:1 }}</td>
+                        <td>{{ raw.raw_humidity|floatformat:1 }}</td>
+                        <td style="text-align:center">{{ form.use_for_alignment }}</td>
+                        <td style="text-align:center">{{ form.use_for_distance }}</td>
+                        <td style="display: none;">{{ form.id }}</td>
+                    </tr>
+                {% endfor %}
+            </table>
+          </div>
         <div class="button-container">
             <a href= "{% url 'baseline_calibration:calibrate1' id=id %}" class="submit-button bg-green-500 hover:bg-green-400" style="text-align: center">Back</button>
-            <a href= "{% url 'baseline_calibration:pillar_survey_del' id=id %}" class="submit-button bg-red-500 hover:bg-green-400" style="text-align: center">Cancel</a>
+            {% if pillar_survey.variance is not null %}
+                <a href= "{% url 'baseline_calibration:calibration_home' %}" class="submit-button bg-red-500 hover:bg-green-400" style="text-align: center"> Cancel</a>
+            {% else %}
+                <a href= "{% url 'baseline_calibration:pillar_survey_del' id=pillar_survey.pk %}" class="submit-button bg-red-500 hover:bg-green-400" style="text-align: center"> Cancel</a>
+            {% endif %}
             <button type="submit" class="submit-button bg-green-500 hover:bg-green-400" >Next</button>
-        </div>     	
+        </div>         
      </form>      
-		<div id="bottom" style="margin-left:auto;margin-right:0;text-align:center;">
-    		<h4>{{ Page }}</h4>
-    </div>   	
-	</div>
+        <div id="bottom" style="margin-left:auto;margin-right:0;text-align:center;">
+            <h4>{{ Page }}</h4>
+    </div>       
+    </div>
 </article>
 
 <script>
@@ -87,7 +91,7 @@ function sortTable(n) {
     /*Loop through all table rows (except the
     first, which contains table headers):*/
     for (i = 1; i 
-	< (rows.length - 1); i++) {
+    < (rows.length - 1); i++) {
       //start by saying there should be no switching:
       shouldSwitch = false;
       /*Get the two elements you want to compare,
@@ -104,7 +108,7 @@ function sortTable(n) {
         }
       } else if (dir == "desc") {
         if (x.innerHTML.toLowerCase() 
-		< y.innerHTML.toLowerCase()) {
+        < y.innerHTML.toLowerCase()) {
           //if so, mark as a switch and break the loop:
           shouldSwitch = true;
           break;

--- a/baseline_calibration/templates/baseline_calibration/uncertainty_budget_form.html
+++ b/baseline_calibration/templates/baseline_calibration/uncertainty_budget_form.html
@@ -55,7 +55,7 @@
                               </tr>
                               {% for error in field.errors %}
                               <tr>
-                                  <td colspan="2">/td>
+                                  <td colspan="2"></td>
                                   <td>
                                       <p style="color:Red;">{{ error }}</p>
                                   </td>

--- a/baseline_calibration/views.py
+++ b/baseline_calibration/views.py
@@ -249,6 +249,7 @@ def calibrate2(request,id):
     pillar_survey_form.is_valid()
     pillar_survey = pillar_survey_form.cleaned_data
     pillar_survey.update({'pk':id})
+    pillar_survey.update({'variance':query_dict['variance']})
     
     # Create some forms to hide on report and commit when submitted
     cd_formset = formset_factory(Certified_DistanceForm, extra=0)    
@@ -320,11 +321,12 @@ def calibrate2(request,id):
         
         formset = zip(edm_obs_formset,raw_edm_obs.values())
         
-        return render(request, 'baseline_calibration/edm_rawdata.html', {
-                                                    'Page': 'Page 5 of 5',
-                                                    'id': id,
-                                                    'edm_obs_formset':edm_obs_formset,
-                                                    'formset': formset})
+        return render(request, 'baseline_calibration/edm_rawdata.html', 
+                      {'Page': 'Page 5 of 5',
+                       'id': id,
+                       'edm_obs_formset':edm_obs_formset,
+                       'pillar_survey': pillar_survey,
+                       'formset': formset})
     else:
         # This is a POST request
         # Apply a mask to the raw observations and recalulate averages and offsets
@@ -665,11 +667,12 @@ def calibrate2(request,id):
             
             return render(request, 'baseline_calibration/calibrate_report.html', context)
    
-    return render(request, 'baseline_calibration/edm_rawdata.html',  {
-                                                'Page': 'Page 5 of 5',
-                                                'id': id,
-                                                'edm_obs_formset':edm_obs_formset,
-                                                'formset': formset})
+    return render(request, 'baseline_calibration/edm_rawdata.html', 
+                  {'Page': 'Page 5 of 5',
+                   'id': id,
+                   'edm_obs_formset':edm_obs_formset,
+                   'pillar_survey': pillar_survey,
+                   'formset': formset})
 
 
 @login_required(login_url="/accounts/login") 

--- a/edm_calibration/forms.py
+++ b/edm_calibration/forms.py
@@ -63,7 +63,7 @@ class CalibrateEdmForm(forms.ModelForm):
            'site': forms.Select(attrs={'class': 'page0'}),
            'auto_base_calibration':forms.CheckboxInput(
                attrs={'onclick':'tglCalibBase()'}),
-           'calibrated_baseline': forms.Select(attrs={'class':'bCalib_slct'}),
+           'calibrated_baseline': forms.Select(attrs={'class':'page0'}),
            'computation_date': forms.DateInput(format=('%d-%m-%Y'),
                attrs={'type':'date', 'class': 'page0'}),
            'survey_date': forms.DateInput(format=('%d-%m-%Y'), 

--- a/edm_calibration/templates/edm_calibration/calibrate.html
+++ b/edm_calibration/templates/edm_calibration/calibrate.html
@@ -23,7 +23,7 @@
                 </colgroup>
                 {% for field in form %}
                     {% if field.name != "auto_base_calibration" %}
-                        <tr class="tgl-{{ field.field.widget.attrs.class }}" style="display:none;">
+                        <tr id="tr-{{field.name}}" class="tgl-{{ field.field.widget.attrs.class }}" style="display:none;">
                             {% if field.field.is_checkbox %}
                                 <td></td>                                        
                                 <td>{{ field }}&emsp; &emsp; {{ field.label }} </td>
@@ -112,7 +112,6 @@ var currentTab = 0;
     {% endif %}
 {% endfor %}
 showTab(currentTab); // Display the current tab
-console.log(lastTab)
 
 function showTab(n) {
   // This function will display the specified tab of the form...
@@ -123,6 +122,7 @@ function showTab(n) {
   
   if (n == 0) {
     document.getElementById("prevBtn").style.display = "none";
+    tglCalibBase()    
   } else {
     document.getElementById("prevBtn").style.display = "inline";
   }
@@ -210,17 +210,21 @@ function ChgNoteFile() {
 function tglCalibBase() {
   // This function will hide/unhide the calibrated baseline select
   var chk = document.getElementById("id_auto_base_calibration");
-  var slct = document.getElementById("id_site");
-  var e = document.getElementsByClassName("tgl-bCalib_slct");
-  for (var i = 0; i < e.length; i++) {
-      if (chk.checked) {
-          e[i].style.display = 'none';
-          slct.disabled = false;
-      } else {
-          e[i].style.display = '';
-          slct.disabled = true;
-          slct.value = ''
-      }
+  var site = document.getElementById("id_site");
+  var tr_calib =  document.getElementById("tr-calibrated_baseline");
+  var slt_calib =  document.getElementById("id_calibrated_baseline");
+  
+  if (chk.checked) {
+      tr_calib.style.display = 'none';
+      site.disabled = false;
+      site.setAttribute("required", "");
+      slt_calib.removeAttribute("required");
+  } else {
+      tr_calib.style.display = '';
+      site.disabled = true;
+      site.value = ''
+      site.removeAttribute("required");
+      slt_calib.setAttribute("required", "");
   }
 }
 </script>

--- a/edm_calibration/templates/edm_calibration/calibrate_report.html
+++ b/edm_calibration/templates/edm_calibration/calibrate_report.html
@@ -52,10 +52,6 @@
                 <div class="flexbox-item_400_IB  flexbox-item-right_IB">
                     <br><B>Manufacturers Uncertainty: </B>{{ pillar_survey.edm.edm_specs.manu_unc_const }}mm &plusmn {{ pillar_survey.edm.edm_specs.manu_unc_ppm }}ppm, k={{ pillar_survey.edm.edm_specs.manu_unc_k }}
                     <br><B>Carrier Wavelength: </B>{{ pillar_survey.edm.edm_specs.carrier_wavelength }}nm
-                    <br><B>Calibration Date : </B>{{ calib.edmi.0.calibration_date }}
-                    {% if calib.edmi.0.calibration_date.certificate_upload %}
-                        <br><a href="{{ calib.edmi.0.calibration_date.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>                
-                    {% endif %}
                 </div>
             </div> 
             <div class="flexbox-container_IB">
@@ -79,8 +75,8 @@
                 <div class="flexbox-item_400_IB  flexbox-item-right_IB">
                     <br><br><B>Manufacturers Uncertainty: </B>{{ pillar_survey.thermometer.mets_specs.manu_unc_const }} &#186C, k={{ pillar_survey.thermometer.mets_specs.manu_unc_k }}
                     <br><B>Calibration Date: </B>{{ calib.them.calibration_date }}
-                    {% if calib.them.calibration_date.certificate_upload %}
-                        <br><a href="{{ calib.them.calibration_date.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>                 
+                    {% if calib.them.certificate_upload %}
+                        <br><a href="{{ calib.them.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>                 
                     {% endif %}
                 </div>
             </div> 
@@ -94,8 +90,8 @@
                 <div class="flexbox-item_400_IB  flexbox-item-right_IB">
                     <br><br><B>Manufacturers Uncertainty: </B>{{ pillar_survey.barometer.mets_specs.manu_unc_const }} hPa, k={{ pillar_survey.barometer.mets_specs.manu_unc_k }}                  
                     <br><B>Calibration Date: </B>{{ calib.baro.calibration_date }}
-                    {% if calib.baro.calibration_date.certificate_upload %}
-                        <br><a href="{{ calib.baro.calibration_date.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>                
+                    {% if calib.baro.certificate_upload %}
+                        <br><a href="{{ calib.baro.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>                
                     {% endif %}
                 </div>
             </div>             
@@ -109,8 +105,8 @@
                 <div class="flexbox-item_400_IB  flexbox-item-right_IB">
                     <br><br><B>Manufacturers Uncertainty: </B>{{ pillar_survey.hygrometer.mets_specs.manu_unc_const }} &#37, k={{ pillar_survey.hygrometer.mets_specs.manu_unc_k }}
                     <br><B>Calibration Date: </B>{{ calib.hygro.calibration_date }}     
-                    {% if calib.hygro.calibration_date.certificate_upload %}
-                        <br><a href="{{ calib.hygro.calibration_date.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>                  
+                    {% if calib.hygro.certificate_upload %}
+                        <br><a href="{{ calib.hygro.certificate_upload.url }}" target="_blank">Download Calibration Certificate &#10515</a>                  
                     {% endif %}
                 </div>
             </div>                    
@@ -132,7 +128,7 @@
                 <B>Date of Baseline Calibration Survey: </B>{{ baseline.calibrated_baseline.survey_date }}
                 <br><B>Date of Calibration Certification: </B>{{ baseline.calibrated_baseline.computation_date }}
                 {% if baseline.calibrated_baseline.accreditation.certificate_upload %}
-                    <br><a href="{{ baseline.calibrated_baseline.accreditation.certificate_upload.url }}" target="_blank">Download Acreditation Certificate &#10515</a>                
+                    <br><a href="{{ baseline.calibrated_baseline.accreditation.certificate_upload.url }}" target="_blank">Download Acreditation Certificate &#10515</a>
                 {% endif %}
             	</div>
             </div>
@@ -222,25 +218,25 @@
             <h2 class="text-center">Estimated Instrument Correction</h2>
 						<div class="flexbox-container_IB">
                 <div class="flexbox-item_800_IB">                
-		                <p>The estimated instrument correction (IC) is to be added to the slope distances measured by set of {{ pillar_survey.edm.edm_specs.edm_model.make.make }} {{ pillar_survey.edm.edm_specs.edm_model.model }} EDM instrument (S/N:{{ pillar_survey.edm.edm_number }}) and prism (S/N:{{ pillar_survey.prism.prism_number }} ) using the following formula:</p>    	                
+		                <p>The estimated instrument correction (IC) is to be added to the slope distances measured by EDMI set of {{ pillar_survey.edm.edm_specs.edm_model.make.make }} {{ pillar_survey.edm.edm_specs.edm_model.model }} EDM instrument (S/N:{{ pillar_survey.edm.edm_number }}) and prism (S/N:{{ pillar_survey.prism.prism_number }} ) using the following formula:</p>    	                
 		                {% if calib.edmi.0.parameters|length > 2 %}
 		                	<p class="text-center"><B>IC = zpc + scf * D + 1C * Sin(2 * &#8508 * D/U) + 2C * Cos(2 * &#8508 * D/U) + 3C * Sin(4 * &#8508 * D/U) + 4C * Cos(4 * &#8508 * D/U)</B></p>
 		                {% else %}
 		               		<p class="text-center"><B>IC = zpc + scf * D</B></p>
 		                {% endif %}
-		                Where:
-		                <br>
-		                <br&nbsp;&nbsp;&nbsp;&nbsp;IC = Instrument Correction (m)
-		                <br>&nbsp;&nbsp;&nbsp;&nbsp;D = Distance (m)
-		                <br>&nbsp;&nbsp;&nbsp;&nbsp;zpc = Zero Point Correction (m)
-		                <br>&nbsp;&nbsp;&nbsp;&nbsp;scf = Scale Correction Factor (1:x)
+		                <p>Where:
+		                <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;IC = Instrument Correction (m)
+		                <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;D = Distance (m)
+		                <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;zpc = Zero Point Correction (m)
+		                <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;scf = Scale Correction Factor (1:x)
 		                {% if calib.edmi.0.parameters|length > 2 %}
-		                    <br>&nbsp;&nbsp;&nbsp;&nbsp;U = Instrument Unit Length (m)
-		                    <br>&nbsp;&nbsp;&nbsp;&nbsp;1C = 1 - Cyclic (1:x)
-		                    <br>&nbsp;&nbsp;&nbsp;&nbsp;2C = 2 - Cyclic (1:x)
-		                    <br>&nbsp;&nbsp;&nbsp;&nbsp;3C = 3 - Cyclic (1:x)
-		                    <br>&nbsp;&nbsp;&nbsp;&nbsp;4C = 4 - Cyclic (1:x)
-		                {% endif %}	                
+		                    <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;U = Instrument Unit Length (m)
+		                    <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1C = 1 - Cyclic (1:x)
+		                    <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2C = 2 - Cyclic (1:x)
+		                    <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3C = 3 - Cyclic (1:x)
+		                    <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4C = 4 - Cyclic (1:x)
+		                {% endif %}
+		                </p>
 		            </div>		            
 		        </div>
 		        <div>
@@ -609,7 +605,11 @@
             <div class="flexbox-container_IB">
                 <div class="flexbox-item_800_IB flexbox-item-button_IB">
                     <a href= "{% url 'edm_calibration:calibrate2' id=pillar_survey.pk %}" class="submit-button bg-green-500 hover:bg-green-400" style="text-align: center">Back</a>
-                    <a href= "{% url 'edm_calibration:edm_calibration_home' %}" class="submit-button bg-red-500 hover:bg-green-400" style="text-align: center">Cancel</a>
+                    {% if pillar_survey.variance is not null %}
+                        <a href= "{% url 'edm_calibration:edm_calibration_home' %}" class="submit-button bg-red-500 hover:bg-green-400" style="text-align: center">Cancel</a>
+                    {% else %}
+                        <a href= "{% url 'edm_calibration:pillar_survey_del' id=pillar_survey.pk %}" class="submit-button bg-red-500 hover:bg-green-400" style="text-align: center"> Cancel</a>
+                    {% endif %}
                     <button type="submit" class="submit-button bg-green-500 hover:bg-green-400" >Save</button>
                 </div>
             </div>

--- a/edm_calibration/templates/edm_calibration/edm_calibration_home.html
+++ b/edm_calibration/templates/edm_calibration/edm_calibration_home.html
@@ -54,7 +54,7 @@
                         <td>{{ pillar_survey.job_number }} </td>
                         <td>
                             <span class="flex justify-around items-center text-center">
-                                <a href="{% url 'edm_calibration:calibrate1' id=pillar_survey.pk %}" target="__blank" class="px-3">
+                                <a href="{% url 'edm_calibration:calibrate1' id=pillar_survey.pk %}" class="px-3">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#000" class="bi bi-pencil-fill" id = "edit-view" viewBox="0 0 16 16">
                                         <path d="M12.854.146a.5.5 0 0 0-.707 0L10.5 1.793 14.207 5.5l1.647-1.646a.5.5 0 0 0 0-.708l-3-3zm.646 6.061L9.793 2.5 3.293 9H3.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.207l6.5-6.5zm-7.468 7.468A.5.5 0 0 1 6 13.5V13h-.5a.5.5 0 0 1-.5-.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.5-.5V10h-.5a.499.499 0 0 1-.175-.032l-.179.178a.5.5 0 0 0-.11.168l-2 5a.5.5 0 0 0 .65.65l5-2a.5.5 0 0 0 .168-.11l.178-.178z"></path>
                                     </svg>

--- a/edm_calibration/templates/edm_calibration/edm_rawdata.html
+++ b/edm_calibration/templates/edm_calibration/edm_rawdata.html
@@ -56,7 +56,11 @@
       	</div>
         <div class="button-container">
             <a href= "{% url 'edm_calibration:calibrate1' id=id %}" class="submit-button bg-green-500 hover:bg-green-400" style="text-align: center">Back</button>
-            <a href= "{% url 'edm_calibration:edm_calibration_home' %}" class="submit-button bg-red-500 hover:bg-green-400" style="text-align: center">Cancel</a>
+            {% if pillar_survey.variance is not null %}
+                <a href= "{% url 'edm_calibration:edm_calibration_home' %}" class="submit-button bg-red-500 hover:bg-green-400" style="text-align: center">Cancel</a>
+            {% else %}
+                <a href= "{% url 'edm_calibration:pillar_survey_del' id=pillar_survey.pk %}" class="submit-button bg-red-500 hover:bg-green-400" style="text-align: center"> Cancel</a>
+            {% endif %}
             <button type="submit" class="submit-button bg-green-500 hover:bg-green-400" >Next</button>
         </div>     	
         </form>      

--- a/edm_calibration/views.py
+++ b/edm_calibration/views.py
@@ -59,11 +59,7 @@ def pillar_survey_del(request, id):
 def calibrate1(request, id):
     if id == 'None':
         qs=''
-        if 'calibrate_e' in request.session:
-            ini_data = request.session['calibrate_e']
-        else:
-            ini_data = {'computation_date':date.today().isoformat()}
-
+        ini_data = {'computation_date':date.today().isoformat()}
         pillar_survey = CalibrateEdmForm(request.POST or None,
                                 request.FILES or None,
                                 user=request.user,
@@ -181,6 +177,7 @@ def calibrate2(request,id):
     pillar_survey_form.is_valid()
     pillar_survey = pillar_survey_form.cleaned_data
     pillar_survey.update({'pk':id})
+    pillar_survey.update({'variance':query_dict['variance']})
     
     # Create form to hide on report and commit when submitted
     pillar_survey_update = PillarSurveyUpdateForm(request.POST or None)
@@ -201,11 +198,12 @@ def calibrate2(request,id):
     if request.method == 'GET':        
         formset = zip(edm_obs_formset, raw_edm_obs.values())
         
-        return render(request, 'edm_calibration/edm_rawdata.html', {
-                                                    'Page': 'Page 5 of 5',
-                                                    'id': id,
-                                                    'edm_obs_formset':edm_obs_formset,
-                                                    'formset': formset})
+        return render(request, 'edm_calibration/edm_rawdata.html', 
+                      {'Page': 'Page 5 of 5',
+                       'id': id,
+                       'edm_obs_formset': edm_obs_formset,
+                       'pillar_survey': pillar_survey,
+                       'formset': formset})
     else:
         # This is a POST request
         # Apply a mask to the raw observations and recheck errors

--- a/instruments/views.py
+++ b/instruments/views.py
@@ -195,7 +195,7 @@ def register_edit(request, inst_disp, tab, id):
         # Convert input to database standard units
         if 'unit_manu_unc_const' in frm.keys():
             instance.manu_unc_const = db_std_units(
-                frm['manu_unc_const'],frm['unit_manu_unc_const'])
+                frm['manu_unc_const']*1000,frm['unit_manu_unc_const'])
         if 'unit_manu_unc_ppm' in frm.keys():                
             if frm['unit_manu_unc_ppm'] == '1:x': 
                 instance.manu_unc_ppm = frm['manu_unc_ppm'] * 1e6


### PR DESCRIPTION
- baseline calibration report - fix links to download calibration certificates
- baseline calibration report - change cancel button link (won't delete saved data)
- edm pillar_survey model changed so baseline calibrations can not be deleted if edmi calibrations use the record
- uncertainty budget form '<' missing from '<tr>' DOM
- edmi calibration report - fix links to download calibration certificates
- edmi calibration report - change cancel button link (won't delete saved data)
- edmi calibrate form - javascript changed to enforce site and baseline_calibration can not both be null
- edmi calibrate form - opens in same tab
- manu_unc_const unit conversion from mm to metres fixed for edm_specifications